### PR TITLE
Add support for rediss:// urls

### DIFF
--- a/lib/queue/index.js
+++ b/lib/queue/index.js
@@ -1,5 +1,19 @@
 import Queue from 'bull';
+import parseDbUrl from 'parse-database-url';
 
-const getQueue = (name) => new Queue(name, process.env.REDIS_URL);
+const REDIS_PARAMS = parseDbUrl(process.env.REDIS_URL);
+const tls = REDIS_PARAMS.driver === 'rediss' ? {} : undefined;
+
+const getQueue = (name) =>
+  new Queue(name, {
+    redis: {
+      username: REDIS_PARAMS.user,
+      password: REDIS_PARAMS.password,
+      host: REDIS_PARAMS.host,
+      port: REDIS_PARAMS.port,
+      connectTimeout: 30000,
+      tls,
+    },
+  });
 
 export default getQueue;


### PR DESCRIPTION
This would support redis clusters offered by PaaS services like DigitalOcean.